### PR TITLE
fix: app crashes on production build

### DIFF
--- a/src/abis/ethereum/index.js
+++ b/src/abis/ethereum/index.js
@@ -1,4 +1,6 @@
-export * as ERC20_ABI from './erc20.json';
-export * as ERC20_BRIDGE_ABI from './erc20-bridge.json';
-export * as ETH_BRIDGE_ABI from './eth-bridge.json';
-export * as MESSAGING_ABI from './messaging.json';
+import ERC20_BRIDGE_ABI from './erc20-bridge.json';
+import ERC20_ABI from './erc20.json';
+import ETH_BRIDGE_ABI from './eth-bridge.json';
+import MESSAGING_ABI from './messaging.json';
+
+export {ERC20_ABI, ERC20_BRIDGE_ABI, ETH_BRIDGE_ABI, MESSAGING_ABI};

--- a/src/abis/starknet/index.js
+++ b/src/abis/starknet/index.js
@@ -1,2 +1,4 @@
-export * as STARKNET_ERC20_ABI from './erc20.json';
-export * as STARKNET_BRIDGE_ABI from './bridge.json';
+import STARKNET_BRIDGE_ABI from './bridge.json';
+import STARKNET_ERC20_ABI from './erc20.json';
+
+export {STARKNET_ERC20_ABI, STARKNET_BRIDGE_ABI};

--- a/src/hooks/useContract.js
+++ b/src/hooks/useContract.js
@@ -17,7 +17,7 @@ export const useContracts = (ABI, getContractHandler = eth_getContract) => {
         }
         return null;
       }),
-    [ABI]
+    [ABI, getContract]
   );
 };
 
@@ -33,7 +33,7 @@ export const useContract = (ABI, getContractHandler = eth_getContract) => {
         return null;
       }
     },
-    [ABI, chainId]
+    [ABI, chainId, getContractHandler]
   );
 };
 
@@ -44,7 +44,7 @@ export const useTokenContract = () => {
   return useCallback(
     tokenAddresses =>
       isEthereum ? getTokenContract(tokenAddresses) : getStarknetTokenContract(tokenAddresses),
-    [isEthereum]
+    [isEthereum, getStarknetTokenContract, getTokenContract]
   );
 };
 
@@ -57,44 +57,44 @@ export const useTokenBridgeContract = () => {
       isEthereum
         ? getTokenBridgeContract(bridgeAddress)
         : getStarknetTokenBridgeContract(bridgeAddress),
-    [isEthereum]
+    [isEthereum, getTokenBridgeContract, getStarknetTokenBridgeContract]
   );
 };
 
 export const useStarknetTokenContract = () => {
   const getContract = useContract(STARKNET_ERC20_ABI, starknet_getContract);
-  return useCallback(tokenAddresses => getContract(tokenAddresses), []);
+  return useCallback(tokenAddresses => getContract(tokenAddresses), [getContract]);
 };
 export const useStarknetTokenContracts = () => {
   const getContracts = useContracts(STARKNET_ERC20_ABI, starknet_getContract);
-  return useCallback(tokensAddresses => getContracts(tokensAddresses), []);
+  return useCallback(tokensAddresses => getContracts(tokensAddresses), [getContracts]);
 };
 export const useEthereumTokenContract = () => {
   const getContract = useContract(ERC20_ABI);
-  return useCallback(tokenAddresses => getContract(tokenAddresses), []);
+  return useCallback(tokenAddresses => getContract(tokenAddresses), [getContract]);
 };
 
 export const useEthereumTokenContracts = () => {
   const getContracts = useContracts(ERC20_ABI);
-  return useCallback(tokensAddresses => getContracts(tokensAddresses), []);
+  return useCallback(tokensAddresses => getContracts(tokensAddresses), [getContracts]);
 };
 
 export const useEthBridgeContract = () => {
   const getContract = useContract(ETH_BRIDGE_ABI);
-  return useMemo(() => getContract(ETH_BRIDGE_CONTRACT_ADDRESS), []);
+  return useMemo(() => getContract(ETH_BRIDGE_CONTRACT_ADDRESS), [getContract]);
 };
 
 export const useMessagingContract = () => {
   const getContract = useContract(MESSAGING_ABI);
-  return useMemo(() => getContract(MESSAGING_CONTRACT_ADDRESS), []);
+  return useMemo(() => getContract(MESSAGING_CONTRACT_ADDRESS), [getContract]);
 };
 
 export const useStarknetTokenBridgeContract = () => {
   const getContract = useContract(STARKNET_BRIDGE_ABI, starknet_getContract);
-  return useCallback(bridgeAddress => getContract(bridgeAddress), []);
+  return useCallback(bridgeAddress => getContract(bridgeAddress), [getContract]);
 };
 
 export const useEthereumTokenBridgeContract = () => {
   const getContract = useContract(ERC20_BRIDGE_ABI);
-  return useCallback(bridgeAddress => getContract(bridgeAddress), []);
+  return useCallback(bridgeAddress => getContract(bridgeAddress), [getContract]);
 };

--- a/src/hooks/useTokenBalance.js
+++ b/src/hooks/useTokenBalance.js
@@ -13,7 +13,7 @@ export const useTokenBalance = account => {
       isEthereum
         ? getEthereumTokenBalance(tokenAddresses)
         : getStarknetTokenBalance(tokenAddresses),
-    [isEthereum, account]
+    [isEthereum, account, getEthereumTokenBalance, getStarknetTokenBalance]
   );
 };
 
@@ -21,7 +21,7 @@ export const useStarknetTokenBalance = account => {
   const getContract = useStarknetTokenContract();
   return useCallback(
     async tokenAddresses => await balanceOf(account, getContract(tokenAddresses), false),
-    [account]
+    [account, getContract]
   );
 };
 
@@ -32,6 +32,6 @@ export const useEthereumTokenBalance = account => {
       tokenAddresses
         ? await balanceOf(account, getContract(tokenAddresses), true)
         : await eth_ethBalanceOf(account),
-    [account]
+    [account, getContract]
   );
 };

--- a/src/providers/TokensProvider/TokensProvider.js
+++ b/src/providers/TokensProvider/TokensProvider.js
@@ -16,6 +16,14 @@ export const TokensProvider = ({children}) => {
   const getEthereumTokenBalance = useEthereumTokenBalance(ethereumAccount);
   const getStarknetTokenBalance = useStarknetTokenBalance(starknetAccount);
 
+  useEffect(() => {
+    updateTokens();
+    const intervalId = setInterval(() => {
+      updateTokens();
+    }, pollBalanceInterval);
+    return () => clearInterval(intervalId);
+  }, [pollBalanceInterval]);
+
   const updateTokens = () => {
     logger.log(`It's time to update tokens balances!`);
     for (let index = 0; index < tokens.length; index++) {
@@ -31,7 +39,7 @@ export const TokensProvider = ({children}) => {
         logger.log(`Token already have a balance of ${token.balance}, don't set isLoading prop`);
       }
       const getBalance = token.isEthereum ? getEthereumTokenBalance : getStarknetTokenBalance;
-      getBalance(tokens[index].tokenAddress)
+      getBalance(token.tokenAddress)
         .then(balance => {
           logger.log(`New ${token.symbol} token balance is ${balance}`);
           updateTokenState(index, {balance, isLoading: false});
@@ -42,14 +50,6 @@ export const TokensProvider = ({children}) => {
         });
     }
   };
-
-  useEffect(() => {
-    updateTokens();
-    const intervalId = setInterval(() => {
-      updateTokens();
-    }, pollBalanceInterval);
-    return () => clearInterval(intervalId);
-  }, []);
 
   const updateTokenState = (index, args) => {
     dispatch({


### PR DESCRIPTION
`export * as someModule from './module.json` exported the file as `Module` instead of `Array`, which cause contract initialization to fail.